### PR TITLE
fix: schedule highlighting auto-enable

### DIFF
--- a/lua/ccc/config/init.lua
+++ b/lua/ccc/config/init.lua
@@ -44,20 +44,22 @@ function M.setup(opt)
     })
 
     if M.config.highlighter.auto_enable then
-        local aug_name = "ccc-highlighter-auto-enable"
-        api.nvim_create_augroup(aug_name, {})
-        api.nvim_create_autocmd("BufEnter", {
-            pattern = "*",
-            group = aug_name,
-            callback = function()
-                local bytes = vim.fn.wordcount().bytes
-                local max_byte = M.config.highlighter.max_byte
-                if bytes > max_byte then
-                    return
-                end
-                require("ccc.highlighter"):enable()
-            end,
-        })
+      vim.schedule(function()
+          local aug_name = "ccc-highlighter-auto-enable"
+          api.nvim_create_augroup(aug_name, {})
+          api.nvim_create_autocmd("BufEnter", {
+              pattern = "*",
+              group = aug_name,
+              callback = function()
+                  local bytes = vim.fn.wordcount().bytes
+                  local max_byte = M.config.highlighter.max_byte
+                  if bytes > max_byte then
+                      return
+                  end
+                  require("ccc.highlighter"):enable()
+              end,
+          })
+      end)
     end
 end
 


### PR DESCRIPTION
With highlighting auto-enabled, there is an error from latest changes because the highlighter is used before initialising.
```
Error detected while processing BufEnter Autocommands for "*":
Error executing lua callback: .../site/pack/packer/start/ccc.nvim/lua/ccc/highlighter.lua:52: attempt to index field 'ft_filter' (a nil value)
stack traceback:
        .../site/pack/packer/start/ccc.nvim/lua/ccc/highlighter.lua:52: in function 'enable'
        .../site/pack/packer/start/ccc.nvim/lua/ccc/config/init.lua:58: in function <.../site/pack/packer/start/ccc.nvim/lua/ccc/config/init.lua:52>
```