### PR TITLE
fix: recreate colors after a colorscheme change

### DIFF
--- a/lua/ccc/config/init.lua
+++ b/lua/ccc/config/init.lua
@@ -48,7 +48,6 @@ function M.setup(opt)
         local aug_name = "ccc-highlighter-auto-enable"
         api.nvim_create_augroup(aug_name, {})
         api.nvim_create_autocmd("BufEnter", {
-            pattern = "*",
             group = aug_name,
             callback = function()
                 local bytes = vim.fn.wordcount().bytes

--- a/lua/ccc/highlighter.lua
+++ b/lua/ccc/highlighter.lua
@@ -14,7 +14,7 @@ local rgb2hex = require("ccc.output.hex").str
 ---@field ft_filter table<string, boolean>
 ---@field lsp boolean
 ---@field hl_mode hl_mode
----@field attached_buffer table<string, boolean>
+---@field attached_buffer table<integer, boolean>
 ---@field ls_colors table<integer, ls_color[]> #Keys are bufnr
 local Highlighter = {}
 
@@ -49,6 +49,15 @@ function Highlighter:init()
     self.hl_mode = config.get("highlight_mode")
     self.attached_buffer = {}
     self.ls_colors = {}
+
+    api.nvim_create_autocmd("ColorScheme", {
+      callback = function()
+        self.is_defined = {}
+        for bufnr in pairs(self.attached_buffer) do
+          self:update(bufnr, 0, -1)
+        end
+      end,
+    })
 end
 
 ---@param bufnr? integer

--- a/lua/ccc/highlighter.lua
+++ b/lua/ccc/highlighter.lua
@@ -132,9 +132,9 @@ function Highlighter:update_lsp(bufnr)
     api.nvim_buf_clear_namespace(bufnr, self.lsp_ns_id, 0, -1)
 
     self.ls_colors[bufnr] = {}
-    for _, client in pairs(vim.lsp.get_active_clients()) do
+    for _, client in pairs(vim.lsp.get_active_clients({bufnr = bufnr})) do
         if client.server_capabilities.colorProvider then
-            local param = { textDocument = vim.lsp.util.make_text_document_params() }
+            local param = { textDocument = vim.lsp.util.make_text_document_params(bufnr) }
             client.request("textDocument/documentColor", param, function(err, color_informations)
                 if err or color_informations == nil then
                     return


### PR DESCRIPTION
Previously, after changing the colorscheme all the highlights disappeared and it was impossible to get them back.  This fixes that. 

I also made some other, unrelated small changes that I found.  I hope that's acceptable, otherwise I could make another PR