### PR TITLE
output: Float representation of RGB colors

### DIFF
--- a/lua/ccc/init.lua
+++ b/lua/ccc/init.lua
@@ -19,6 +19,7 @@ local M = {
         hex_short = require("ccc.output.hex_short"),
         css_rgb = require("ccc.output.css_rgb"),
         css_hsl = require("ccc.output.css_hsl"),
+        float   = require("ccc.output.float"),
     },
     picker = {
         hex = require("ccc.picker.hex"),

--- a/lua/ccc/output/float.lua
+++ b/lua/ccc/output/float.lua
@@ -1,0 +1,25 @@
+local convert = require("ccc.utils.convert")
+
+---@class FloatOutput: ColorOutput
+local FloatOutput = {
+    name = "Float",
+}
+
+---@param RGB number[]
+---@param A? number
+---@return string
+function FloatOutput.str(RGB, A)
+    local R, G, B = convert.rgb_format(RGB)
+    R = R / 256
+    G = G / 256
+    B = B / 256
+    if A then
+        local pattern = "(%#.3f,%#.3f,%#.3f,%#.3f)"
+        return pattern:format(R, G, B, A)
+    else
+        local pattern = "(%#.3f,%#.3f,%#.3f)"
+        return pattern:format(R, G, B)
+    end
+end
+
+return FloatOutput


### PR DESCRIPTION
Some plataforms represent RGB colors as floats numbers between 0.0 and 1.0 instead of 0 and 255.
Examples are OpenGL and Love2d.

This patch allows one to output the colors directly in this representation. I've found it really useful for working with GLSL, for example.