### PR TITLE
feat: support keyword 'none'.

### DIFF
--- a/lua/ccc/picker/picker_spec.lua
+++ b/lua/ccc/picker/picker_spec.lua
@@ -43,6 +43,10 @@ describe("Color detection test", function()
         require("ccc").setup({})
     end)
 
+    it("none", function()
+        test(css_rgb, " rgb(255 none 255) ", { 255, 0, 255 }, nil)
+    end)
+
     describe("hex", function()
         it("6 digits", function()
             test(hex, " #ffff00 ", { 255, 255, 0 }, nil)

--- a/lua/ccc/utils/parse.lua
+++ b/lua/ccc/utils/parse.lua
@@ -45,6 +45,9 @@ end
 ---@param str string
 ---@return number? deg #Normalized degree in the range [0-360].
 function parse.hue(str)
+    if str == "none" then
+        return 0
+    end
     local num = parse.number(str) or parse.angle(str)
     if num then
         return num % 360
@@ -70,6 +73,10 @@ end
 ---@param percent? boolean #Default: false. If true, return range is corrected to [0-1]
 ---@return number?
 function parse.percent(str, ratio, percent)
+    if str == "none" then
+        return 0
+    end
+
     ratio = vim.F.if_nil(ratio, 1)
     percent = vim.F.if_nil(percent, false)
 
@@ -98,7 +105,9 @@ end
 ---@param str? string
 ---@return number? #Range in [0-1]
 function parse.alpha(str)
-    if str == nil then
+    if str == "none" then
+        return 0
+    elseif str == nil then
         return
     end
     return parse.percent(str)


### PR DESCRIPTION
interpolation is not considered and is simply as a zero value.
