### PR TITLE
fix: return early when it has no entries

### DIFF
--- a/lua/ccc/picker/custom_entries.lua
+++ b/lua/ccc/picker/custom_entries.lua
@@ -5,25 +5,16 @@ local pattern = require("ccc.utils.pattern")
 ---@field rgb { [string]: integer[] }
 ---@field min_length integer
 ---@field color_table { [string]: string }
----@field disabled boolean
 local CustomEntries = {}
 
 ---@param color_table { [string]: string }
 ---@return CustomEntries
 CustomEntries.new = function(color_table)
-  return setmetatable(
-    { color_table = color_table, rgb = {}, min_length = 0, disabled = false },
-    { __index = CustomEntries }
-  )
+  return setmetatable({ color_table = color_table, rgb = {}, min_length = 0 }, { __index = CustomEntries })
 end
 
 function CustomEntries:init()
   if self.pattern then
-    return
-  end
-  if vim.tbl_isempty(self.color_table) then
-    vim.notify("[ccc] no entries for the custom_entries picker", vim.log.levels.WARN)
-    self.disabled = true
     return
   end
   ---@type { plain: string, vim: string }[]
@@ -57,7 +48,8 @@ end
 ---@return RGB?
 ---@return Alpha?
 function CustomEntries:parse_color(s, init)
-  if self.disabled then
+  if vim.tbl_isempty(self.color_table) then
+    vim.notify("[ccc] no entries for the custom_entries picker", vim.log.levels.WARN)
     return
   end
   self:init()

--- a/lua/ccc/picker/custom_entries.lua
+++ b/lua/ccc/picker/custom_entries.lua
@@ -49,7 +49,7 @@ end
 ---@return Alpha?
 function CustomEntries:parse_color(s, init)
   if vim.tbl_isempty(self.color_table) then
-    vim.notify("[ccc] no entries for the custom_entries picker", vim.log.levels.WARN)
+    vim.notify_once("[ccc] no entries for the custom_entries picker", vim.log.levels.WARN)
     return
   end
   self:init()

--- a/lua/ccc/picker/custom_entries.lua
+++ b/lua/ccc/picker/custom_entries.lua
@@ -49,6 +49,7 @@ end
 ---@return Alpha?
 function CustomEntries:parse_color(s, init)
   if vim.tbl_isempty(self.color_table) then
+    vim.notify("[ccc] no entries for the custom_entries picker", vim.log.levels.WARN)
     return
   end
   self:init()

--- a/lua/ccc/picker/custom_entries.lua
+++ b/lua/ccc/picker/custom_entries.lua
@@ -5,16 +5,25 @@ local pattern = require("ccc.utils.pattern")
 ---@field rgb { [string]: integer[] }
 ---@field min_length integer
 ---@field color_table { [string]: string }
+---@field disabled boolean
 local CustomEntries = {}
 
 ---@param color_table { [string]: string }
 ---@return CustomEntries
 CustomEntries.new = function(color_table)
-  return setmetatable({ color_table = color_table, rgb = {}, min_length = 0 }, { __index = CustomEntries })
+  return setmetatable(
+    { color_table = color_table, rgb = {}, min_length = 0, disabled = false },
+    { __index = CustomEntries }
+  )
 end
 
 function CustomEntries:init()
   if self.pattern then
+    return
+  end
+  if vim.tbl_isempty(self.color_table) then
+    vim.notify("[ccc] no entries for the custom_entries picker", vim.log.levels.WARN)
+    self.disabled = true
     return
   end
   ---@type { plain: string, vim: string }[]
@@ -48,8 +57,7 @@ end
 ---@return RGB?
 ---@return Alpha?
 function CustomEntries:parse_color(s, init)
-  if vim.tbl_isempty(self.color_table) then
-    vim.notify("[ccc] no entries for the custom_entries picker", vim.log.levels.WARN)
+  if self.disabled then
     return
   end
   self:init()

--- a/lua/ccc/picker/custom_entries.lua
+++ b/lua/ccc/picker/custom_entries.lua
@@ -48,6 +48,9 @@ end
 ---@return RGB?
 ---@return Alpha?
 function CustomEntries:parse_color(s, init)
+  if vim.tbl_isempty(self.color_table) then
+    return
+  end
   self:init()
   init = vim.F.if_nil(init, 1) --[[@as integer]]
   if #s - init + 1 < self.min_length then


### PR DESCRIPTION
I found `init()` occurs errors on this line below when `self.color_table` is an empty table: `{}`. This fixes it.

https://github.com/uga-rosa/ccc.nvim/blob/3d2020703c10385970032acda4f2efe0679458d1/lua/ccc/picker/custom_entries.lua#L37