### PR TITLE
Fallback to default highlighting if not set

### DIFF
--- a/lua/ccc/ui/float.lua
+++ b/lua/ccc/ui/float.lua
@@ -42,12 +42,21 @@ function UI:open(color, prev_colors)
   vim.api.nvim_set_option_value("modifiable", false, { buf = self.bufnr })
   vim.api.nvim_set_option_value("filetype", "ccc-ui", { buf = self.bufnr })
   vim.api.nvim_set_option_value("signcolumn", "no", { win = self.winid })
+
   -- Set highlight
+
   local float_normal = vim.api.nvim_get_hl(0, { name = "CccFloatNormal" }) --[[@as vim.api.keyset.highlight]]
   local float_border = vim.api.nvim_get_hl(0, { name = "CccFloatBorder" }) --[[@as vim.api.keyset.highlight]]
-  vim.api.nvim_set_hl(self.ns_id, "Normal", float_normal)
-  vim.api.nvim_set_hl(self.ns_id, "EndOfBuffer", float_normal)
-  vim.api.nvim_set_hl(self.ns_id, "FloatBorder", float_border)
+
+  -- fallback to global highlight if not set
+  if next(float_normal) then
+    vim.api.nvim_set_hl(self.ns_id, "Normal", float_normal)
+    vim.api.nvim_set_hl(self.ns_id, "EndOfBuffer", float_normal)
+  end
+  if next(float_border) then
+    vim.api.nvim_set_hl(self.ns_id, "FloatBorder", float_border)
+  end
+
   -- For callback
   self.is_quit = true
   -- Clean up on closing a window


### PR DESCRIPTION
I think we should use the default highlighting name if the theme does not support the specific highlighting name. For example, the default theme doesn't support CccFloatNormal and CccFloatBorder, but almost all themes support NormalFloat and FloatBorder. So, if CccFloatBorder is not found, it will be white, making it look ugly.
![image](https://github.com/uga-rosa/ccc.nvim/assets/92097639/290569ea-595d-4941-a954-847a3b9bb563)
If we fallback to the default name, it will improve the user experience.
![image](https://github.com/uga-rosa/ccc.nvim/assets/92097639/494b130d-4720-49cf-ac5d-45ad77fcc85b)

