### PR TITLE
feat: add picker.hex_long/short

### DIFF
--- a/doc/ccc.txt
+++ b/doc/ccc.txt
@@ -251,6 +251,8 @@ Default: {
 	List of formats that can be detected by |:CccPick| to be activated.
 	The presets currently available are as follows:
 		- HEX       ccc.picker.hex
+		            ccc.picker.hex_long (#RRGGBB, #RRGGBBAA)
+		            ccc.picker.hex_short (#RGB, #RGBA)
 		- CssRGB    ccc.picker.css_rgb
 		- CssHSL    ccc.picker.css_hsl
 		- CssHWB    ccc.picker.css_hwb

--- a/lua/ccc/config/default.lua
+++ b/lua/ccc/config/default.lua
@@ -85,6 +85,8 @@ return {
         [picker.css_rgb]   = { input.rgb,   output.css_rgb   },
         [picker.css_name]  = { input.rgb,   output.css_rgb   },
         [picker.hex]       = { input.rgb,   output.hex       },
+        [picker.hex_long]  = { input.rgb,   output.hex       },
+        [picker.hex_short] = { input.rgb,   output.hex_short },
         [picker.css_hsl]   = { input.hsl,   output.css_hsl   },
         [picker.css_hwb]   = { input.hwb,   output.css_hwb   },
         [picker.css_lab]   = { input.lab,   output.css_lab   },

--- a/lua/ccc/picker/hex.lua
+++ b/lua/ccc/picker/hex.lua
@@ -3,23 +3,18 @@ local pattern = require("ccc.utils.pattern")
 
 ---@class ccc.ColorPicker.Hex: ccc.ColorPicker
 ---@field pattern string[]
-local HexPicker = {}
-
-function HexPicker:init()
-  if self.pattern then
-    return
-  end
+local HexPicker = {
   -- #RRGGBB
-  -- #RGB
   -- #RRGGBBAA
+  -- #RGB
   -- #RGBA
-  self.pattern = {
+  pattern = {
     [=[\v%(^|[^[:keyword:]])\zs#(\x\x)(\x\x)(\x\x)>]=],
-    [=[\v%(^|[^[:keyword:]])\zs#(\x)(\x)(\x)>]=],
     [=[\v%(^|[^[:keyword:]])\zs#(\x\x)(\x\x)(\x\x)(\x\x)>]=],
+    [=[\v%(^|[^[:keyword:]])\zs#(\x)(\x)(\x)>]=],
     [=[\v%(^|[^[:keyword:]])\zs#(\x)(\x)(\x)(\x)>]=],
-  }
-end
+  },
+}
 
 ---@param s string
 ---@param init? integer
@@ -28,7 +23,6 @@ end
 ---@return number[]? rgb
 ---@return number? alpha
 function HexPicker:parse_color(s, init)
-  self:init()
   init = init or 1
   -- The shortest patten is 4 characters like `#fff`
   while init <= #s - 3 do

--- a/lua/ccc/picker/hex_long.lua
+++ b/lua/ccc/picker/hex_long.lua
@@ -1,0 +1,13 @@
+local HexPicker = require("ccc.picker.hex")
+
+---@class ccc.ColorPicker.HexLong: ccc.ColorPicker.Hex
+local HexLongPicker = setmetatable({}, { __index = HexPicker })
+
+-- #RRGGBB
+-- #RRGGBBAA
+HexLongPicker.pattern = {
+  [=[\v%(^|[^[:keyword:]])\zs#(\x\x)(\x\x)(\x\x)>]=],
+  [=[\v%(^|[^[:keyword:]])\zs#(\x\x)(\x\x)(\x\x)(\x\x)>]=],
+}
+
+return HexLongPicker

--- a/lua/ccc/picker/hex_short.lua
+++ b/lua/ccc/picker/hex_short.lua
@@ -1,0 +1,13 @@
+local HexPicker = require("ccc.picker.hex")
+
+---@class ccc.ColorPicker.HexLong: ccc.ColorPicker.Hex
+local HexLongPicker = setmetatable({}, { __index = HexPicker })
+
+-- #RGB
+-- #RGBA
+HexLongPicker.pattern = {
+  [=[\v%(^|[^[:keyword:]])\zs#(\x)(\x)(\x)>]=],
+  [=[\v%(^|[^[:keyword:]])\zs#(\x)(\x)(\x)(\x)>]=],
+}
+
+return HexLongPicker


### PR DESCRIPTION
close #119

To easily specify only long/short hex.

```lua
local ccc = require'ccc'
ccc.setup {
  pickers = {
    ccc.picker.hex_long,
    ccc.picker.css_rgb,
    -- ...
  }
}
```
