### PR TITLE
feat: use non-deprecated LSP methods when available

### DIFF
--- a/lua/ccc/handler/lsp.lua
+++ b/lua/ccc/handler/lsp.lua
@@ -61,7 +61,11 @@ function LspHandler:update(bufnr)
   ---@diagnostic disable-next-line
   local clients = (vim.lsp.get_clients or vim.lsp.get_active_clients)({ bufnr = bufnr })
   clients = vim.tbl_filter(function(client)
-    return client.supports_method(method, { bufnr = bufnr })
+    if vim.fn.has("nvim-0.11") then
+      return client:supports_method(method, { bufnr = bufnr })
+    else
+      return client.supports_method(method, { bufnr = bufnr })
+    end
   end, clients)
   -- Number of clients who responsed
   local result_count = 0

--- a/lua/ccc/kit/LSP/Client.lua
+++ b/lua/ccc/kit/LSP/Client.lua
@@ -11,6 +11,15 @@ Client.__index = Client
 ---@return ccc.kit.LSP.Client
 function Client.new(client)
   local self = setmetatable({}, Client)
+
+  if vim.fn.has("nvim-0.11") == 0 then
+    client = setmetatable({
+      request = function(_, ...)
+        return client.request(...)
+      end,
+    }, { __index = client })
+  end
+
   self.client = client
   return self
 end
@@ -19,7 +28,7 @@ end
 function Client:textDocument_implementation(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/implementation", params, function(err, res)
+    request_id = self.client:request("textDocument/implementation", params, function(err, res)
       if err then
         reject(err)
       else
@@ -39,7 +48,7 @@ end
 function Client:textDocument_typeDefinition(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/typeDefinition", params, function(err, res)
+    request_id = self.client:request("textDocument/typeDefinition", params, function(err, res)
       if err then
         reject(err)
       else
@@ -59,7 +68,7 @@ end
 function Client:workspace_workspaceFolders(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("workspace/workspaceFolders", params, function(err, res)
+    request_id = self.client:request("workspace/workspaceFolders", params, function(err, res)
       if err then
         reject(err)
       else
@@ -81,7 +90,7 @@ end
 function Client:workspace_configuration(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("workspace/configuration", params, function(err, res)
+    request_id = self.client:request("workspace/configuration", params, function(err, res)
       if err then
         reject(err)
       else
@@ -101,7 +110,7 @@ end
 function Client:textDocument_documentColor(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/documentColor", params, function(err, res)
+    request_id = self.client:request("textDocument/documentColor", params, function(err, res)
       if err then
         reject(err)
       else
@@ -121,7 +130,7 @@ end
 function Client:textDocument_colorPresentation(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/colorPresentation", params, function(err, res)
+    request_id = self.client:request("textDocument/colorPresentation", params, function(err, res)
       if err then
         reject(err)
       else
@@ -141,7 +150,7 @@ end
 function Client:textDocument_foldingRange(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/foldingRange", params, function(err, res)
+    request_id = self.client:request("textDocument/foldingRange", params, function(err, res)
       if err then
         reject(err)
       else
@@ -161,7 +170,7 @@ end
 function Client:textDocument_declaration(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/declaration", params, function(err, res)
+    request_id = self.client:request("textDocument/declaration", params, function(err, res)
       if err then
         reject(err)
       else
@@ -181,7 +190,7 @@ end
 function Client:textDocument_selectionRange(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/selectionRange", params, function(err, res)
+    request_id = self.client:request("textDocument/selectionRange", params, function(err, res)
       if err then
         reject(err)
       else
@@ -201,7 +210,7 @@ end
 function Client:window_workDoneProgress_create(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("window/workDoneProgress/create", params, function(err, res)
+    request_id = self.client:request("window/workDoneProgress/create", params, function(err, res)
       if err then
         reject(err)
       else
@@ -221,7 +230,7 @@ end
 function Client:textDocument_prepareCallHierarchy(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/prepareCallHierarchy", params, function(err, res)
+    request_id = self.client:request("textDocument/prepareCallHierarchy", params, function(err, res)
       if err then
         reject(err)
       else
@@ -241,7 +250,7 @@ end
 function Client:callHierarchy_incomingCalls(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("callHierarchy/incomingCalls", params, function(err, res)
+    request_id = self.client:request("callHierarchy/incomingCalls", params, function(err, res)
       if err then
         reject(err)
       else
@@ -261,7 +270,7 @@ end
 function Client:callHierarchy_outgoingCalls(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("callHierarchy/outgoingCalls", params, function(err, res)
+    request_id = self.client:request("callHierarchy/outgoingCalls", params, function(err, res)
       if err then
         reject(err)
       else
@@ -281,7 +290,7 @@ end
 function Client:textDocument_semanticTokens_full(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/semanticTokens/full", params, function(err, res)
+    request_id = self.client:request("textDocument/semanticTokens/full", params, function(err, res)
       if err then
         reject(err)
       else
@@ -301,7 +310,7 @@ end
 function Client:textDocument_semanticTokens_full_delta(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/semanticTokens/full/delta", params, function(err, res)
+    request_id = self.client:request("textDocument/semanticTokens/full/delta", params, function(err, res)
       if err then
         reject(err)
       else
@@ -321,7 +330,7 @@ end
 function Client:textDocument_semanticTokens_range(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/semanticTokens/range", params, function(err, res)
+    request_id = self.client:request("textDocument/semanticTokens/range", params, function(err, res)
       if err then
         reject(err)
       else
@@ -341,7 +350,7 @@ end
 function Client:workspace_semanticTokens_refresh(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("workspace/semanticTokens/refresh", params, function(err, res)
+    request_id = self.client:request("workspace/semanticTokens/refresh", params, function(err, res)
       if err then
         reject(err)
       else
@@ -361,7 +370,7 @@ end
 function Client:window_showDocument(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("window/showDocument", params, function(err, res)
+    request_id = self.client:request("window/showDocument", params, function(err, res)
       if err then
         reject(err)
       else
@@ -381,7 +390,7 @@ end
 function Client:textDocument_linkedEditingRange(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/linkedEditingRange", params, function(err, res)
+    request_id = self.client:request("textDocument/linkedEditingRange", params, function(err, res)
       if err then
         reject(err)
       else
@@ -401,7 +410,7 @@ end
 function Client:workspace_willCreateFiles(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("workspace/willCreateFiles", params, function(err, res)
+    request_id = self.client:request("workspace/willCreateFiles", params, function(err, res)
       if err then
         reject(err)
       else
@@ -421,7 +430,7 @@ end
 function Client:workspace_willRenameFiles(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("workspace/willRenameFiles", params, function(err, res)
+    request_id = self.client:request("workspace/willRenameFiles", params, function(err, res)
       if err then
         reject(err)
       else
@@ -441,7 +450,7 @@ end
 function Client:workspace_willDeleteFiles(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("workspace/willDeleteFiles", params, function(err, res)
+    request_id = self.client:request("workspace/willDeleteFiles", params, function(err, res)
       if err then
         reject(err)
       else
@@ -461,7 +470,7 @@ end
 function Client:textDocument_moniker(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/moniker", params, function(err, res)
+    request_id = self.client:request("textDocument/moniker", params, function(err, res)
       if err then
         reject(err)
       else
@@ -481,7 +490,7 @@ end
 function Client:textDocument_prepareTypeHierarchy(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/prepareTypeHierarchy", params, function(err, res)
+    request_id = self.client:request("textDocument/prepareTypeHierarchy", params, function(err, res)
       if err then
         reject(err)
       else
@@ -501,7 +510,7 @@ end
 function Client:typeHierarchy_supertypes(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("typeHierarchy/supertypes", params, function(err, res)
+    request_id = self.client:request("typeHierarchy/supertypes", params, function(err, res)
       if err then
         reject(err)
       else
@@ -521,7 +530,7 @@ end
 function Client:typeHierarchy_subtypes(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("typeHierarchy/subtypes", params, function(err, res)
+    request_id = self.client:request("typeHierarchy/subtypes", params, function(err, res)
       if err then
         reject(err)
       else
@@ -541,7 +550,7 @@ end
 function Client:textDocument_inlineValue(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/inlineValue", params, function(err, res)
+    request_id = self.client:request("textDocument/inlineValue", params, function(err, res)
       if err then
         reject(err)
       else
@@ -561,7 +570,7 @@ end
 function Client:workspace_inlineValue_refresh(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("workspace/inlineValue/refresh", params, function(err, res)
+    request_id = self.client:request("workspace/inlineValue/refresh", params, function(err, res)
       if err then
         reject(err)
       else
@@ -581,7 +590,7 @@ end
 function Client:textDocument_inlayHint(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/inlayHint", params, function(err, res)
+    request_id = self.client:request("textDocument/inlayHint", params, function(err, res)
       if err then
         reject(err)
       else
@@ -601,7 +610,7 @@ end
 function Client:inlayHint_resolve(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("inlayHint/resolve", params, function(err, res)
+    request_id = self.client:request("inlayHint/resolve", params, function(err, res)
       if err then
         reject(err)
       else
@@ -621,7 +630,7 @@ end
 function Client:workspace_inlayHint_refresh(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("workspace/inlayHint/refresh", params, function(err, res)
+    request_id = self.client:request("workspace/inlayHint/refresh", params, function(err, res)
       if err then
         reject(err)
       else
@@ -641,7 +650,7 @@ end
 function Client:textDocument_diagnostic(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/diagnostic", params, function(err, res)
+    request_id = self.client:request("textDocument/diagnostic", params, function(err, res)
       if err then
         reject(err)
       else
@@ -661,7 +670,7 @@ end
 function Client:workspace_diagnostic(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("workspace/diagnostic", params, function(err, res)
+    request_id = self.client:request("workspace/diagnostic", params, function(err, res)
       if err then
         reject(err)
       else
@@ -681,7 +690,7 @@ end
 function Client:workspace_diagnostic_refresh(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("workspace/diagnostic/refresh", params, function(err, res)
+    request_id = self.client:request("workspace/diagnostic/refresh", params, function(err, res)
       if err then
         reject(err)
       else
@@ -701,7 +710,7 @@ end
 function Client:client_registerCapability(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("client/registerCapability", params, function(err, res)
+    request_id = self.client:request("client/registerCapability", params, function(err, res)
       if err then
         reject(err)
       else
@@ -721,7 +730,7 @@ end
 function Client:client_unregisterCapability(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("client/unregisterCapability", params, function(err, res)
+    request_id = self.client:request("client/unregisterCapability", params, function(err, res)
       if err then
         reject(err)
       else
@@ -741,7 +750,7 @@ end
 function Client:initialize(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("initialize", params, function(err, res)
+    request_id = self.client:request("initialize", params, function(err, res)
       if err then
         reject(err)
       else
@@ -761,7 +770,7 @@ end
 function Client:shutdown(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("shutdown", params, function(err, res)
+    request_id = self.client:request("shutdown", params, function(err, res)
       if err then
         reject(err)
       else
@@ -781,7 +790,7 @@ end
 function Client:window_showMessageRequest(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("window/showMessageRequest", params, function(err, res)
+    request_id = self.client:request("window/showMessageRequest", params, function(err, res)
       if err then
         reject(err)
       else
@@ -801,7 +810,7 @@ end
 function Client:textDocument_willSaveWaitUntil(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/willSaveWaitUntil", params, function(err, res)
+    request_id = self.client:request("textDocument/willSaveWaitUntil", params, function(err, res)
       if err then
         reject(err)
       else
@@ -821,7 +830,7 @@ end
 function Client:textDocument_completion(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/completion", params, function(err, res)
+    request_id = self.client:request("textDocument/completion", params, function(err, res)
       if err then
         reject(err)
       else
@@ -841,7 +850,7 @@ end
 function Client:completionItem_resolve(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("completionItem/resolve", params, function(err, res)
+    request_id = self.client:request("completionItem/resolve", params, function(err, res)
       if err then
         reject(err)
       else
@@ -861,7 +870,7 @@ end
 function Client:textDocument_hover(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/hover", params, function(err, res)
+    request_id = self.client:request("textDocument/hover", params, function(err, res)
       if err then
         reject(err)
       else
@@ -881,7 +890,7 @@ end
 function Client:textDocument_signatureHelp(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/signatureHelp", params, function(err, res)
+    request_id = self.client:request("textDocument/signatureHelp", params, function(err, res)
       if err then
         reject(err)
       else
@@ -901,7 +910,7 @@ end
 function Client:textDocument_definition(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/definition", params, function(err, res)
+    request_id = self.client:request("textDocument/definition", params, function(err, res)
       if err then
         reject(err)
       else
@@ -921,7 +930,7 @@ end
 function Client:textDocument_references(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/references", params, function(err, res)
+    request_id = self.client:request("textDocument/references", params, function(err, res)
       if err then
         reject(err)
       else
@@ -941,7 +950,7 @@ end
 function Client:textDocument_documentHighlight(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/documentHighlight", params, function(err, res)
+    request_id = self.client:request("textDocument/documentHighlight", params, function(err, res)
       if err then
         reject(err)
       else
@@ -961,7 +970,7 @@ end
 function Client:textDocument_documentSymbol(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/documentSymbol", params, function(err, res)
+    request_id = self.client:request("textDocument/documentSymbol", params, function(err, res)
       if err then
         reject(err)
       else
@@ -981,7 +990,7 @@ end
 function Client:textDocument_codeAction(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/codeAction", params, function(err, res)
+    request_id = self.client:request("textDocument/codeAction", params, function(err, res)
       if err then
         reject(err)
       else
@@ -1001,7 +1010,7 @@ end
 function Client:codeAction_resolve(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("codeAction/resolve", params, function(err, res)
+    request_id = self.client:request("codeAction/resolve", params, function(err, res)
       if err then
         reject(err)
       else
@@ -1021,7 +1030,7 @@ end
 function Client:workspace_symbol(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("workspace/symbol", params, function(err, res)
+    request_id = self.client:request("workspace/symbol", params, function(err, res)
       if err then
         reject(err)
       else
@@ -1041,7 +1050,7 @@ end
 function Client:workspaceSymbol_resolve(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("workspaceSymbol/resolve", params, function(err, res)
+    request_id = self.client:request("workspaceSymbol/resolve", params, function(err, res)
       if err then
         reject(err)
       else
@@ -1061,7 +1070,7 @@ end
 function Client:textDocument_codeLens(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/codeLens", params, function(err, res)
+    request_id = self.client:request("textDocument/codeLens", params, function(err, res)
       if err then
         reject(err)
       else
@@ -1081,7 +1090,7 @@ end
 function Client:codeLens_resolve(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("codeLens/resolve", params, function(err, res)
+    request_id = self.client:request("codeLens/resolve", params, function(err, res)
       if err then
         reject(err)
       else
@@ -1101,7 +1110,7 @@ end
 function Client:workspace_codeLens_refresh(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("workspace/codeLens/refresh", params, function(err, res)
+    request_id = self.client:request("workspace/codeLens/refresh", params, function(err, res)
       if err then
         reject(err)
       else
@@ -1121,7 +1130,7 @@ end
 function Client:textDocument_documentLink(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/documentLink", params, function(err, res)
+    request_id = self.client:request("textDocument/documentLink", params, function(err, res)
       if err then
         reject(err)
       else
@@ -1141,7 +1150,7 @@ end
 function Client:documentLink_resolve(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("documentLink/resolve", params, function(err, res)
+    request_id = self.client:request("documentLink/resolve", params, function(err, res)
       if err then
         reject(err)
       else
@@ -1161,7 +1170,7 @@ end
 function Client:textDocument_formatting(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/formatting", params, function(err, res)
+    request_id = self.client:request("textDocument/formatting", params, function(err, res)
       if err then
         reject(err)
       else
@@ -1181,7 +1190,7 @@ end
 function Client:textDocument_rangeFormatting(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/rangeFormatting", params, function(err, res)
+    request_id = self.client:request("textDocument/rangeFormatting", params, function(err, res)
       if err then
         reject(err)
       else
@@ -1201,7 +1210,7 @@ end
 function Client:textDocument_onTypeFormatting(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/onTypeFormatting", params, function(err, res)
+    request_id = self.client:request("textDocument/onTypeFormatting", params, function(err, res)
       if err then
         reject(err)
       else
@@ -1221,7 +1230,7 @@ end
 function Client:textDocument_rename(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/rename", params, function(err, res)
+    request_id = self.client:request("textDocument/rename", params, function(err, res)
       if err then
         reject(err)
       else
@@ -1241,7 +1250,7 @@ end
 function Client:textDocument_prepareRename(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("textDocument/prepareRename", params, function(err, res)
+    request_id = self.client:request("textDocument/prepareRename", params, function(err, res)
       if err then
         reject(err)
       else
@@ -1261,7 +1270,7 @@ end
 function Client:workspace_executeCommand(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("workspace/executeCommand", params, function(err, res)
+    request_id = self.client:request("workspace/executeCommand", params, function(err, res)
       if err then
         reject(err)
       else
@@ -1281,7 +1290,7 @@ end
 function Client:workspace_applyEdit(params)
   local that, request_id, reject_ = self, nil, nil
   local task = AsyncTask.new(function(resolve, reject)
-    request_id = self.client.request("workspace/applyEdit", params, function(err, res)
+    request_id = self.client:request("workspace/applyEdit", params, function(err, res)
       if err then
         reject(err)
       else


### PR DESCRIPTION
Gets rid of the deprecation warnings on nightly Neovim (see https://github.com/neovim/neovim/pull/31207).