### PR TITLE
fix: replace missing `client.request` reference

### DIFF
--- a/lua/ccc/handler/lsp.lua
+++ b/lua/ccc/handler/lsp.lua
@@ -71,7 +71,7 @@ function LspHandler:update(bufnr)
   local result_count = 0
   local color_informations = {}
   for _, client in ipairs(clients) do
-    client.request(method, param, function(err, result)
+    client:request(method, param, function(err, result)
       result_count = result_count + 1
       if result and err == nil then
         vim.list_extend(color_informations, result)


### PR DESCRIPTION
Follow-up from https://github.com/uga-rosa/ccc.nvim/pull/138. I forgot the replace this reference.