### PR TITLE
Bugfix: point color wasn't applied when point_idx = 0

### DIFF
--- a/lua/ccc/ui/float.lua
+++ b/lua/ccc/ui/float.lua
@@ -157,7 +157,8 @@ end
 ---@return integer
 local function adjust2bar(value, min, max)
   local opts = require("ccc.config").options
-  return utils.round((value - min) / (max - min) * opts.bar_len)
+  local raw = utils.round((value - min) / (max - min) * opts.bar_len)
+  return utils.clamp(raw, 1, opts.bar_len)
 end
 
 ---@param value number
@@ -167,9 +168,6 @@ end
 local function create_bar(value, min, max)
   local opts = require("ccc.config").options
   local point_idx = adjust2bar(value, min, max)
-  if point_idx == 0 then
-    return opts.point_char .. opts.bar_char:rep(opts.bar_len - 1)
-  end
   return opts.bar_char:rep(point_idx - 1) .. opts.point_char .. opts.bar_char:rep(opts.bar_len - point_idx)
 end
 
@@ -242,7 +240,7 @@ function UI:highlight(width)
       local new_value = (j - 0.5) / opts.bar_len * (max - min) + min
       local hex = self.color:hex(i, new_value)
       local hl = { fg = hex }
-      if j == point_idx or j == 1 and point_idx == 0 then
+      if j == point_idx then
         if not opts.empty_point_bg then
           local RGB = self.color:get_rgb()
           local R, G, B = convert.rgb_format(RGB)
@@ -281,7 +279,7 @@ function UI:highlight(width)
       local alpha_ratio = (i - 0.5) / opts.bar_len
       local hex = self.color.alpha:hex(alpha_ratio)
       local hl = { fg = hex }
-      if i == point_idx or i == 1 and point_idx == 0 then
+      if i == point_idx then
         if not opts.empty_point_bg then
           hl = {
             fg = alpha_ratio > 0.5 and opts.point_color_on_dark or opts.point_color_on_light,

--- a/lua/ccc/ui/float.lua
+++ b/lua/ccc/ui/float.lua
@@ -242,7 +242,7 @@ function UI:highlight(width)
       local new_value = (j - 0.5) / opts.bar_len * (max - min) + min
       local hex = self.color:hex(i, new_value)
       local hl = { fg = hex }
-      if j == point_idx then
+      if j == point_idx or j == 1 and point_idx == 0 then
         if not opts.empty_point_bg then
           local RGB = self.color:get_rgb()
           local R, G, B = convert.rgb_format(RGB)
@@ -281,7 +281,7 @@ function UI:highlight(width)
       local alpha_ratio = (i - 0.5) / opts.bar_len
       local hex = self.color.alpha:hex(alpha_ratio)
       local hl = { fg = hex }
-      if i == point_idx then
+      if i == point_idx or i == 1 and point_idx == 0 then
         if not opts.empty_point_bg then
           hl = {
             fg = alpha_ratio > 0.5 and opts.point_color_on_dark or opts.point_color_on_light,


### PR DESCRIPTION
The color of points wasn't being applied when they're all the way to the left. In that case, the default light/dark colors are being applied instead.

To reproduce:

1. set a point color (that isn't black/white)
2. reduce RGB, HSL, or alpha to 0
3. point color is being shown in black (or white)

The issue is that the for loops for the bars in `UI:highlight` range from 1-width. That means that `point_idx` never matches when it is 0.

### Before

Alpha point is black in stead of red:

![Screenshot 2025-05-04 at 2 32 36 PM](https://github.com/user-attachments/assets/1806f963-53ce-4a3f-812a-2e91157ce27e)

Alpha point only becomes red when point_idx  is >= 1:

![Screenshot 2025-05-04 at 2 32 52 PM](https://github.com/user-attachments/assets/67d74a94-501e-4dc8-ba40-f001fd2afc2d)

### After

Hue, saturation, and alpha are correctly shown in red:

![Screenshot 2025-05-04 at 3 19 16 PM](https://github.com/user-attachments/assets/2caee584-b89f-4847-9b89-6ecf339572d6)

### Demo

Shows 0 values and editing in action with actual styling:

https://github.com/user-attachments/assets/1c6239e2-21a5-4038-acbb-e031df4f99b0
